### PR TITLE
chore: combine jobs in workflow

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -22,9 +22,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build_src:
+  # deploy
+  deploy:
+    needs: build_src
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    name: Build the scr folder
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,23 +41,16 @@ jobs:
 
       - name: display output
         run: ls
-  # deploy
-  deploy:
-    needs: build_src
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './build'
+          
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Combine both jobs in the workflow to be only one, so that the deploy script can access the build artefacts.